### PR TITLE
Version 1.1.0: Migration to Redux

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,9 +16,12 @@
         "@types/node": "^16.11.56",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
+        "@types/redux": "^3.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.0.4",
         "react-scripts": "5.0.1",
+        "redux": "^4.2.0",
         "socket.io-client": "^4.5.2",
         "typescript": "^4.8.2"
       },
@@ -4840,6 +4843,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -4955,6 +4967,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/redux": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@types/redux/-/redux-3.6.0.tgz",
+      "integrity": "sha512-ic+60DXHW5seNyqFvfr7Sk5cnXs+HsF9tIeIaxjOuSP5kzgDXC+AzKTYmjAfuLx4Sccm/0vjwBQj3OOkUkwOqg==",
+      "deprecated": "This is a stub types definition for Redux (https://github.com/reactjs/redux). Redux provides its own type definitions, so you don't need @types/redux installed!",
+      "dependencies": {
+        "redux": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -5007,6 +5028,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -15141,6 +15167,49 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-redux": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.4.tgz",
+      "integrity": "sha512-yMfQ7mX6bWuicz2fids6cR1YT59VTuT8MKyyE310wJQlINKENCeT1UcPdEiX6znI5tF8zXyJ/VYvDgeGuaaNwQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -17099,6 +17168,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -21446,6 +21523,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -21561,6 +21647,14 @@
         "@types/react": "*"
       }
     },
+    "@types/redux": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@types/redux/-/redux-3.6.0.tgz",
+      "integrity": "sha512-ic+60DXHW5seNyqFvfr7Sk5cnXs+HsF9tIeIaxjOuSP5kzgDXC+AzKTYmjAfuLx4Sccm/0vjwBQj3OOkUkwOqg==",
+      "requires": {
+        "redux": "*"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -21613,6 +21707,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -28779,6 +28878,26 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-redux": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.4.tgz",
+      "integrity": "sha512-yMfQ7mX6bWuicz2fids6cR1YT59VTuT8MKyyE310wJQlINKENCeT1UcPdEiX6znI5tF8zXyJ/VYvDgeGuaaNwQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -30207,6 +30326,12 @@
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.2.9",
         "@emotion/react": "^11.10.0",
         "@emotion/styled": "^11.10.0",
+        "@reduxjs/toolkit": "^1.8.5",
         "@types/node": "^16.11.56",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
@@ -4357,6 +4358,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.5.tgz",
+      "integrity": "sha512-f4D5EXO7A7Xq35T0zRbWq5kJQyXzzscnHKmjnu2+37B3rwHU6mX9PYlbfXdnxcY6P/7zfmjhgan0Z+yuOfeBmA==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15318,6 +15342,22 @@
         "node": "*"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -15459,6 +15499,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -21064,6 +21109,17 @@
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+    },
+    "@reduxjs/toolkit": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.5.tgz",
+      "integrity": "sha512-f4D5EXO7A7Xq35T0zRbWq5kJQyXzzscnHKmjnu2+37B3rwHU6mX9PYlbfXdnxcY6P/7zfmjhgan0Z+yuOfeBmA==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -28858,6 +28914,20 @@
         }
       }
     },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -28968,6 +29038,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,9 +16,12 @@
     "@types/node": "^16.11.56",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "@types/redux": "^3.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.0.4",
     "react-scripts": "5.0.1",
+    "redux": "^4.2.0",
     "socket.io-client": "^4.5.2",
     "typescript": "^4.8.2"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@chakra-ui/react": "^2.2.9",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
+    "@reduxjs/toolkit": "^1.8.5",
     "@types/node": "^16.11.56",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import MetadataDisplay from './components/MetadataDisplay';
 
 function App() {
   const dispatch = useAppDispatch();
+
   useEffect(() => {
     dispatch(socketConnect());
   }, []);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { io } from 'socket.io-client';
 import { Spacer, VStack } from '@chakra-ui/react';
 
 import { useAppDispatch } from './app/hooks';
@@ -12,16 +11,17 @@ import MetadataDisplay from './components/MetadataDisplay';
 function App() {
   const dispatch = useAppDispatch();
   useEffect(() => {
+    console.log('connect to socket');
     dispatch(socketConnect());
   }, []);
 
   return (
     <section className="app">
       <VStack spacing={8}>
-        <HeadlineDisplay headline={headline} />
-        <MetadataDisplay createdAt={createdAt} updatedAt={updatedAt} taps={taps} />
+        <HeadlineDisplay />
+        <MetadataDisplay />
         <Spacer />
-        <HeadlineInput emitNew={emitNew} />
+        <HeadlineInput />
       </VStack>
     </section>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { io } from 'socket.io-client';
 import { Spacer, VStack } from '@chakra-ui/react';
 
-import IHeadline from './api/headline';
+import { useAppDispatch } from './app/hooks';
+import { socketConnect } from './constants/actionCreators';
 
 import HeadlineDisplay from './components/HeadlineDisplay';
 import HeadlineInput from './components/HeadlineInput';
@@ -11,24 +12,10 @@ import MetadataDisplay from './components/MetadataDisplay';
 const socket = io();
 
 function App() {
-  const [{
-    headline, createdAt, updatedAt, taps,
-  }, setHeadlineData] = useState<IHeadline>({
-    headline: '',
-    createdAt: '',
-    updatedAt: '',
-    taps: 0,
-  });
-
+  const dispatch = useAppDispatch();
   useEffect(() => {
-    socket.on('headline', (data: IHeadline) => {
-      setHeadlineData(data);
-    });
+    dispatch(socketConnect());
   }, []);
-
-  const emitNew = (inputHeadline: string) => {
-    socket.emit('new', inputHeadline);
-  };
 
   return (
     <section className="app">

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,7 +11,6 @@ import MetadataDisplay from './components/MetadataDisplay';
 function App() {
   const dispatch = useAppDispatch();
   useEffect(() => {
-    console.log('connect to socket');
     dispatch(socketConnect());
   }, []);
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,8 +9,6 @@ import HeadlineDisplay from './components/HeadlineDisplay';
 import HeadlineInput from './components/HeadlineInput';
 import MetadataDisplay from './components/MetadataDisplay';
 
-const socket = io();
-
 function App() {
   const dispatch = useAppDispatch();
   useEffect(() => {

--- a/client/src/app/hooks.ts
+++ b/client/src/app/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/client/src/app/hooks.ts
+++ b/client/src/app/hooks.ts
@@ -2,6 +2,5 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { TypedUseSelectorHook } from 'react-redux';
 import type { RootState, AppDispatch } from './store';
 
-// Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/client/src/app/middleware/websocket.ts
+++ b/client/src/app/middleware/websocket.ts
@@ -18,7 +18,6 @@ const websocketMiddleware: Middleware<{}, RootState> = (store) => (next) => (act
 
       // socket listeners lives in middleware
       socket.on('headline', (headline) => {
-        console.log(headline);
         store.dispatch(headlineSet(headline));
       });
       break;

--- a/client/src/app/middleware/websocket.ts
+++ b/client/src/app/middleware/websocket.ts
@@ -22,6 +22,7 @@ const websocketMiddleware: Middleware<{}, RootState> = (store) => (next) => (act
       });
       break;
     }
+    // socket emits live in middleware
     case HEADLINE_UPDATE: {
       if (socket) {
         socket.emit('new', action.payload);

--- a/client/src/app/middleware/websocket.ts
+++ b/client/src/app/middleware/websocket.ts
@@ -2,26 +2,39 @@ import { Middleware } from 'redux';
 import { io, Socket } from 'socket.io-client';
 
 import { RootState } from '../store';
-import { SOCKET_CONNECT } from '../../constants/actionNames';
+import { SOCKET_CONNECT, HEADLINE_UPDATE } from '../../constants/actionNames';
 import { headlineSet } from '../../constants/actionCreators';
 
 let socket: Socket | null = null;
 
 const websocketMiddleware: Middleware<{}, RootState> = (store) => (next) => (action) => {
-  if (action.type === SOCKET_CONNECT) {
-    if (socket) {
-      socket.disconnect();
-    }
-    // socket will live in middleware
-    socket = io();
+  switch (action.type) {
+    case SOCKET_CONNECT: {
+      // if (socket) {
+      //   socket.disconnect();
+      // }
+      // socket will live in middleware
+      socket = io();
 
-    // socket listeners also live in middleware
-    socket.on('headline', (headline) => {
-      store.dispatch(headlineSet(headline));
-    });
+      // socket listeners lives in middleware
+      socket.on('headline', (headline) => {
+        console.log(headline);
+        store.dispatch(headlineSet(headline));
+      });
+      break;
+    }
+    case HEADLINE_UPDATE: {
+      if (socket) {
+        socket.emit('new', action.payload);
+      }
+      break;
+    }
+    default: {
+      break;
+    }
   }
 
-  return next({ ...action, socket });
+  return next(action);
 };
 
 export default websocketMiddleware;

--- a/client/src/app/middleware/websocket.ts
+++ b/client/src/app/middleware/websocket.ts
@@ -10,9 +10,9 @@ let socket: Socket | null = null;
 const websocketMiddleware: Middleware<{}, RootState> = (store) => (next) => (action) => {
   switch (action.type) {
     case SOCKET_CONNECT: {
-      // if (socket) {
-      //   socket.disconnect();
-      // }
+      if (socket) {
+        socket.disconnect();
+      }
       // socket will live in middleware
       socket = io();
 

--- a/client/src/app/middleware/websocket.ts
+++ b/client/src/app/middleware/websocket.ts
@@ -1,0 +1,27 @@
+import { Middleware } from 'redux';
+import { io, Socket } from 'socket.io-client';
+
+import { RootState } from '../store';
+import { SOCKET_CONNECT } from '../../constants/actionNames';
+import { headlineSet } from '../../constants/actionCreators';
+
+let socket: Socket | null = null;
+
+const websocketMiddleware: Middleware<{}, RootState> = (store) => (next) => (action) => {
+  if (action.type === SOCKET_CONNECT) {
+    if (socket) {
+      socket.disconnect();
+    }
+    // socket will live in middleware
+    socket = io();
+
+    // socket listeners also live in middleware
+    socket.on('headline', (headline) => {
+      store.dispatch(headlineSet(headline));
+    });
+  }
+
+  return next({ ...action, socket });
+};
+
+export default websocketMiddleware;

--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -1,0 +1,16 @@
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+
+import websocketMiddleware from './middleware/websocket';
+import headlineReducer from '../features/headlineSlice';
+
+const rootReducer = combineReducers({
+  headline: headlineReducer,
+});
+
+export const store = configureStore({
+  reducer: rootReducer,
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(websocketMiddleware),
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+export type AppDispatch = typeof store.dispatch;

--- a/client/src/components/HeadlineDisplay.tsx
+++ b/client/src/components/HeadlineDisplay.tsx
@@ -3,11 +3,11 @@ import {
   Box,
 } from '@chakra-ui/react';
 
-interface HeadlineDisplayProps {
-  headline: string;
-}
+import { useAppSelector } from '../app/hooks';
 
-function HeadlineDisplay({ headline }: HeadlineDisplayProps) {
+function HeadlineDisplay() {
+  const headline = useAppSelector((state) => state.headline.headline);
+
   return (
     <Box
       borderWidth="1px"

--- a/client/src/components/HeadlineInput.tsx
+++ b/client/src/components/HeadlineInput.tsx
@@ -8,13 +8,14 @@ import {
 } from '@chakra-ui/react';
 import { ArrowForwardIcon } from '@chakra-ui/icons';
 
+import { useAppDispatch } from '../app/hooks';
+import { headlineUpdate } from '../constants/actionCreators';
+
 const HEADLINE_LENGTH_LIMIT = 64;
 
-interface HeadlineInputProps {
-  emitNew: (inputHeadline: string) => void;
-}
+function HeadlineInput() {
+  const dispatch = useAppDispatch();
 
-function HeadlineInput({ emitNew }: HeadlineInputProps) {
   const [inputHeadline, setInputHeadline] = useState('');
 
   const toast = useToast();
@@ -34,7 +35,7 @@ function HeadlineInput({ emitNew }: HeadlineInputProps) {
       });
     } else if (inputHeadline.trim()) {
       // input headline is valid
-      emitNew(inputHeadline);
+      dispatch(headlineUpdate(inputHeadline));
       setInputHeadline('');
       toast.closeAll();
     } else if (!toast.isActive('headline-doens\'t-exist')) {

--- a/client/src/components/MetadataDisplay.tsx
+++ b/client/src/components/MetadataDisplay.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 
 import { Text, HStack } from '@chakra-ui/react';
+import { useAppSelector } from '../app/hooks';
 
 const DateTimeOptions: Intl.DateTimeFormatOptions = {
   dateStyle: 'medium',
   timeStyle: 'short',
 };
 
-type MetadataDisplayProps = {
-  createdAt: string;
-  updatedAt: string;
-  taps: number;
-};
+function MetadataDisplay() {
+  const createdAt = useAppSelector((state) => state.headline.createdAt);
+  const updatedAt = useAppSelector((state) => state.headline.updatedAt);
+  const taps = useAppSelector((state) => state.headline.taps);
 
-function MetadataDisplay({ createdAt, updatedAt, taps }: MetadataDisplayProps) {
   const createdDateObj = new Date(createdAt);
   const updatedDateObj = new Date(updatedAt);
 

--- a/client/src/constants/actionCreators.ts
+++ b/client/src/constants/actionCreators.ts
@@ -1,12 +1,14 @@
 import IHeadline from '../api/headline';
 import { SOCKET_CONNECT, HEADLINE_UPDATE, HEADLINE_SET } from './actionNames';
 
+// @desc Creates initial socket.io connection
 export function socketConnect() {
   return {
     type: SOCKET_CONNECT,
   };
 }
 
+// @desc Updates the headline document in MongoDB
 export function headlineUpdate(headline: string) {
   return {
     type: HEADLINE_UPDATE,
@@ -14,6 +16,7 @@ export function headlineUpdate(headline: string) {
   };
 }
 
+// @desc Updates the headline object in Redux store
 export function headlineSet(headline: IHeadline) {
   return {
     type: HEADLINE_SET,

--- a/client/src/constants/actionCreators.ts
+++ b/client/src/constants/actionCreators.ts
@@ -1,9 +1,16 @@
 import IHeadline from '../api/headline';
-import { SOCKET_CONNECT, HEADLINE_SET } from './actionNames';
+import { SOCKET_CONNECT, HEADLINE_UPDATE, HEADLINE_SET } from './actionNames';
 
 export function socketConnect() {
   return {
     type: SOCKET_CONNECT,
+  };
+}
+
+export function headlineUpdate(headline: string) {
+  return {
+    type: HEADLINE_UPDATE,
+    payload: headline,
   };
 }
 

--- a/client/src/constants/actionCreators.ts
+++ b/client/src/constants/actionCreators.ts
@@ -1,0 +1,15 @@
+import IHeadline from '../api/headline';
+import { SOCKET_CONNECT, HEADLINE_SET } from './actionNames';
+
+export function socketConnect() {
+  return {
+    type: SOCKET_CONNECT,
+  };
+}
+
+export function headlineSet(headline: IHeadline) {
+  return {
+    type: HEADLINE_SET,
+    payload: headline,
+  };
+}

--- a/client/src/constants/actionNames.ts
+++ b/client/src/constants/actionNames.ts
@@ -1,3 +1,8 @@
+// initates socket connection in middleware
 export const SOCKET_CONNECT = 'socket/connect';
 
-export const HEADLINE_SET = 'headline/setHeadline';
+// updates headline value in server
+export const HEADLINE_UPDATE = 'headline/update';
+
+// sets headline value in store
+export const HEADLINE_SET = 'headline/set';

--- a/client/src/constants/actionNames.ts
+++ b/client/src/constants/actionNames.ts
@@ -1,0 +1,3 @@
+export const SOCKET_CONNECT = 'socket/connect';
+
+export const HEADLINE_SET = 'headline/setHeadline';

--- a/client/src/features/headlineSlice.ts
+++ b/client/src/features/headlineSlice.ts
@@ -2,7 +2,6 @@ import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
 import IHeadline from '../api/headline';
-import { HEADLINE_SET } from '../constants/actionNames';
 
 const initialState: IHeadline = {
   headline: '',
@@ -15,7 +14,7 @@ export const headlineSlice = createSlice({
   name: 'headline',
   initialState,
   reducers: {
-    [HEADLINE_SET]: (state, action: PayloadAction<IHeadline>) => action.payload,
+    set: (state, action: PayloadAction<IHeadline>) => action.payload,
     // setHeadline will ONLY be called through socketMiddleware
     // client imput will only change server value,
     // which in turn will send a new socket to update the store

--- a/client/src/features/headlineSlice.ts
+++ b/client/src/features/headlineSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+import IHeadline from '../api/headline';
+import { HEADLINE_SET } from '../constants/actionNames';
+
+const initialState: IHeadline = {
+  headline: '',
+  createdAt: '',
+  updatedAt: '',
+  taps: 0,
+};
+
+export const headlineSlice = createSlice({
+  name: 'headline',
+  initialState,
+  reducers: {
+    [HEADLINE_SET]: (state, action: PayloadAction<IHeadline>) => action.payload,
+    // setHeadline will ONLY be called through socketMiddleware
+    // client imput will only change server value,
+    // which in turn will send a new socket to update the store
+  },
+});
+
+export default headlineSlice.reducer;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
+import { Provider } from 'react-redux';
 
 import App from './App';
+import { store } from './app/store';
 
 import './index.css';
 
@@ -12,7 +14,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ChakraProvider>
-      <App />
+      <Provider store={store}>
+        <App />
+      </Provider>
     </ChakraProvider>
   </React.StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tapin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tapin",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In version 1.0.0, the client's socket.io instance was integrated in the root component ([`App.tsx`](client/src/App.tsx)), requiring the data pulled from the socket connection to be individually passed throughout the component tree. 

In version 1.1.0, the client's socket.io instance now persists in the Redux lifecycle; specifically, a Redux middleware. The connection establishes and listens in the middleware. Any socket emits now exist as Redux actions; action creators send an action through the Redux lifecycle, interpreted thought the socket.io middleware, and emits the action. 